### PR TITLE
Use Picsum Images Instead of Lorem Pixel

### DIFF
--- a/client/components/ImageSelection.jsx
+++ b/client/components/ImageSelection.jsx
@@ -7,9 +7,10 @@ const Thumbnail = styled.div`
   width: 57px;
   background-image: url(${(props) => props.productImage});
   background-size: cover;
-  margin: 0px 5px;
   border: ${(props) => (props.selected ? '3px solid teal;' : 'none;')}
   border-radius: 5px;
+  cursor: pointer;
+  margin: 0px 5px;
   &:first-child {
     margin: 0px 5px 0px 0px;
   }
@@ -21,7 +22,6 @@ const Wrapper = styled.div`
   flex-wrap: no-wrap;
   align-items: center;
   margin: 10px 0px;
-  cursor: pointer;
 `;
 
 const ImageSelection = ({ productImages, selectedImageIndex, selectImage }) => {
@@ -31,7 +31,7 @@ const ImageSelection = ({ productImages, selectedImageIndex, selectImage }) => {
         <Thumbnail
           productImage={productImage}
           selected={selectedImageIndex === i}
-          key={i}
+          key={productImage}
           onClick={() => selectImage(i)}
           id={`thumbnail-${i}`}
         />

--- a/fakeDataGen.js
+++ b/fakeDataGen.js
@@ -1,20 +1,30 @@
-const faker = require('faker');
 const mongoose = require('mongoose');
 const fs = require('fs');
 
 // Output array
 const outputArray = [];
 
-// Seed so we can reuse this file and get the same results
-faker.seed(100);
-
 // Create 100 records
 const numRecords = 100;
 for (let i = 1; i <= numRecords; i++) {
-  const numOfImages = faker.random.number({ min: 1, max: 10 });
+  const imageIds = [
+    445,
+    3,
+    225,
+    21,
+    20,
+    201,
+    2,
+    180,
+    160,
+    119
+  ];
+
+  const numOfImages = Math.floor(Math.random() * Math.floor(imageIds.length - 1)) + 1;
+
   const imagesArray = [];
   for (let j = 0; j < numOfImages; j++) {
-    imagesArray.push(faker.image.imageUrl(650, 400));
+    imagesArray.push(`http://picsum.photos/id/${imageIds[j]}/650/400`);
   }
 
   const record = {

--- a/fakeDataGen.js
+++ b/fakeDataGen.js
@@ -7,7 +7,6 @@ const outputArray = [];
 // Create 100 records
 const numRecords = 100;
 for (let i = 1; i <= numRecords; i++) {
-
   // Selection of ids from Picsum images for pictures that resemble products
   const picsumImageIds = [445, 3, 225, 21, 20, 201, 2, 180, 160, 119];
 

--- a/fakeDataGen.js
+++ b/fakeDataGen.js
@@ -7,24 +7,15 @@ const outputArray = [];
 // Create 100 records
 const numRecords = 100;
 for (let i = 1; i <= numRecords; i++) {
-  const imageIds = [
-    445,
-    3,
-    225,
-    21,
-    20,
-    201,
-    2,
-    180,
-    160,
-    119
-  ];
 
-  const numOfImages = Math.floor(Math.random() * Math.floor(imageIds.length - 1)) + 1;
+  // Selection of ids from Picsum images for pictures that resemble products
+  const picsumImageIds = [445, 3, 225, 21, 20, 201, 2, 180, 160, 119];
+
+  const numOfImages = Math.floor(Math.random() * (picsumImageIds.length - 1)) + 1;
 
   const imagesArray = [];
   for (let j = 0; j < numOfImages; j++) {
-    imagesArray.push(`http://picsum.photos/id/${imageIds[j]}/650/400`);
+    imagesArray.push(`http://picsum.photos/id/${picsumImageIds[j]}/650/400`);
   }
 
   const record = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4018,11 +4018,6 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
-    "faker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
-      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
-    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "jest": "^24.9.0",
     "jsdom": "^15.2.0",
     "nodemon": "^1.19.3",
-    "react-test-renderer": "^16.10.2",
     "style-loader": "^1.0.0",
     "supertest": "^4.0.2",
     "webpack": "^4.41.0",
@@ -47,7 +46,6 @@
   },
   "dependencies": {
     "express": "^4.17.1",
-    "faker": "^4.1.0",
     "mongoose": "^5.7.4",
     "prop-types": "^15.7.2",
     "react": "^16.10.2",
@@ -59,6 +57,8 @@
     "coveragePathIgnorePatterns": [
       "/node_modules"
     ],
-    "setupFilesAfterEnv": ["./tests/setup.js"]
+    "setupFilesAfterEnv": [
+      "./tests/setup.js"
+    ]
   }
 }


### PR DESCRIPTION
Updated `fakeDataGen.js` to use a selection of Picsum images instead of Lorem Pixel images. Lore Pixel provided the same image for each thumbnail. Furthermore, because Lorem Pixel urls are the same for all images, I couldn't use it as a unique key in my ImageSelection component.