### PR TITLE
Add Image Selection Chevrons

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react"]
+  "presets": ["@babel/preset-env", "@babel/preset-react"],
+  "plugins": ["babel-plugin-styled-components"]
 }

--- a/client/components/HoverMessage.jsx
+++ b/client/components/HoverMessage.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const SmallMessage = styled.div`
+  font-size: 12px;
+  color: #333;
+  text-align: center;
+  font-family: sans-serif;
+  width: 650px;
+`;
+
+const Compart = styled.span`
+font-size: 17px
+`;
+
+const HoverMessage = () => (
+  <SmallMessage>
+    <Compart>&#8853;&nbsp;</Compart>
+    Hover Over to Zoom In
+  </SmallMessage>
+);
+
+export default HoverMessage;

--- a/client/components/ImageSelection.jsx
+++ b/client/components/ImageSelection.jsx
@@ -1,42 +1,114 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import ThumbnailChevron from './ThumbnailChevron';
+import calculatePages from '../helpers/calculatePages';
 
 const Thumbnail = styled.div`
   height: 57px;
   width: 57px;
   background-image: url(${(props) => props.productImage});
   background-size: cover;
-  border: ${(props) => (props.selected ? '3px solid teal;' : 'none;')}
+  position: relative;
   border-radius: 5px;
   cursor: pointer;
   margin: 0px 5px;
   &:first-child {
     margin: 0px 5px 0px 0px;
   }
+  display: inline-block;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  ${(props) => {
+    if (props.selected) {
+      return `
+        &:after {
+          content: '';
+          position: absolute;
+          top: 4px;
+          left: 4px;
+          right: 4px;
+          bottom: 4px;
+          z-index: 1;
+          border-radius:1px
+          box-shadow:
+            0 0 0 2px #fff,
+            0 0 0 4px #0076d6;
+        }
+      `;
+    }
+    return null;
+  }}
 `;
 
-const Wrapper = styled.div`
+const ImageContainer = styled.div`
   display: flex;
   flex-direction: row;
   flex-wrap: no-wrap;
-  align-items: center;
-  margin: 10px 0px;
+  transition: transform .25s;
+  transform: translate(${(props) => props.translate}px, 0px);
+  padding: ${(props) => (props.cursors ? '0px 20px' : '0px 0px')};
 `;
 
-const ImageSelection = ({ productImages, selectedImageIndex, selectImage }) => (
-  <Wrapper>
-    {productImages.map((productImage, i) => (
-      <Thumbnail
-        productImage={productImage}
-        selected={selectedImageIndex === i}
-        key={productImage}
-        onClick={() => selectImage(i)}
-        id={`thumbnail-${i}`}
-      />
-    ))}
-  </Wrapper>
-);
+const Mask = styled.div`
+  overflow: hidden;
+  margin: 10px 0px;
+  width: 650px;
+  position: relative;
+`;
+
+const ImageSelection = ({ productImages, selectedImageIndex, selectImage }) => {
+  const translations = calculatePages(productImages.length);
+  const [page, setPage] = useState(0);
+
+  useEffect(() => {
+    setPage(Math.floor(selectedImageIndex / 9));
+  }, [selectedImageIndex]);
+
+  const handleLeftClick = () => {
+    if (page === 0) {
+      setPage(translations.length - 1);
+    } else {
+      setPage(page - 1);
+    }
+  };
+
+  const handleRightClick = () => {
+    if (page === translations.length - 1) {
+      setPage(0);
+    } else {
+      setPage(page + 1);
+    }
+  };
+
+  return (
+    <>
+      <Mask>
+        <ImageContainer
+          cursors={productImages.length > 9}
+          translate={translations[page]}
+          className="image-container"
+        >
+          {productImages.map((productImage, i) => (
+            <Thumbnail
+              productImage={productImage}
+              selected={selectedImageIndex === i}
+              key={productImage}
+              onClick={() => selectImage(i)}
+              id={`thumbnail-${i}`}
+            />
+          ))}
+        </ImageContainer>
+        {productImages.length <= 9
+          ? null
+          : <ThumbnailChevron direction="left" handleClick={handleLeftClick} />}
+        {productImages.length <= 9
+          ? null
+          : <ThumbnailChevron direction="right" handleClick={handleRightClick} />}
+      </Mask>
+    </>
+  );
+};
 
 ImageSelection.propTypes = {
   productImages: PropTypes.arrayOf(PropTypes.string).isRequired,

--- a/client/components/MainPicture.jsx
+++ b/client/components/MainPicture.jsx
@@ -15,6 +15,7 @@ const Img = styled.img`
   transition: transform .15s, transform-origin .15s;
   transform-origin: ${(props) => props.transformOrigin};
   transform: scale(${(props) => props.scale});
+  border-radius: 5px;
 `;
 
 const Wrapper = styled.div`

--- a/client/components/SlideShow.jsx
+++ b/client/components/SlideShow.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import MainPicture from './MainPicture';
 import ImageSelection from './ImageSelection';
+import HoverMessage from './HoverMessage';
 
 const SlideShow = ({ productImages }) => {
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
@@ -31,6 +32,7 @@ const SlideShow = ({ productImages }) => {
         increaseSelectedImage={increaseSelectedImage}
         decreaseSelectedImage={decreaseSelectedImage}
       />
+      <HoverMessage />
       <ImageSelection
         productImages={productImages}
         selectedImageIndex={selectedImageIndex}

--- a/client/components/ThumbnailChevron.jsx
+++ b/client/components/ThumbnailChevron.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+const Chevron = styled.div`
+  position: absolute;
+  top: 0px;
+  left: ${(props) => (props.direction === 'left' ? 0 : 635)}px;
+  height: 100%;
+  background-color: #404040;
+  display: inline-block;
+  width: 15px;
+  border-radius: 3px;
+  cursor: pointer;
+`;
+
+const Polyline = styled.polyline.attrs(({ direction }) => ({
+  points: direction === 'left' ? '18 20 6 12 18 4' : '6 20 18 12 6 4'
+}))`
+  stroke: white;
+  stroke-width: 2;
+  fill: none;
+`;
+
+const Svg = styled.svg.attrs(() => ({
+  viewBox: '0 0 24 24'
+}))`
+  height: 100%;
+  width: 100%;
+`;
+
+const ThumbnailChevron = ({ direction, handleClick }) => (
+  <Chevron direction={direction} onClick={handleClick}>
+    <Svg>
+      <Polyline direction={direction} />
+    </Svg>
+  </Chevron>
+);
+
+ThumbnailChevron.propTypes = {
+  direction: PropTypes.string.isRequired,
+  handleClick: PropTypes.func.isRequired
+};
+
+export default ThumbnailChevron;

--- a/client/helpers/calculatePages.js
+++ b/client/helpers/calculatePages.js
@@ -1,0 +1,23 @@
+// One full page = 603px, 9 images
+
+// Each image is 67px
+
+const calculatePages = (productImagesNum) => {
+  const out = [];
+
+  const fullPages = Math.floor(productImagesNum / 9);
+  for (let i = 0; i < fullPages; i++) {
+    if (i === 0) {
+      out.push(0);
+    } else {
+      out.push(i * -603);
+    }
+  }
+
+  const remainingImages = productImagesNum % 9;
+  out.push(out[out.length - 1] - (remainingImages * 63) + 5);
+
+  return out;
+};
+
+export default calculatePages;

--- a/fakeDataGen.js
+++ b/fakeDataGen.js
@@ -10,11 +10,19 @@ for (let i = 1; i <= numRecords; i++) {
   // Selection of ids from Picsum images for pictures that resemble products
   const picsumImageIds = [445, 3, 225, 21, 20, 201, 2, 180, 160, 119];
 
-  const numOfImages = Math.floor(Math.random() * (picsumImageIds.length - 1)) + 1;
-
   const imagesArray = [];
-  for (let j = 0; j < numOfImages; j++) {
-    imagesArray.push(`http://picsum.photos/id/${picsumImageIds[j]}/650/400`);
+
+  // For the very first record, have LOTS of images
+  if (i === 1) {
+    for (let j = 0; j < picsumImageIds.length * 2; j++) {
+      const id = picsumImageIds[j % picsumImageIds.length];
+      imagesArray.push(`http://picsum.photos/id/${id}/650/400#${j}`);
+    }
+  } else {
+    const numOfImages = Math.floor(Math.random() * (picsumImageIds.length - 1)) + 1;
+    for (let j = 1; j < numOfImages; j++) {
+      imagesArray.push(`http://picsum.photos/id/${picsumImageIds[j]}/650/400`);
+    }
   }
 
   const record = {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@babel/preset-react": "^7.6.3",
     "babel-jest": "^24.9.0",
     "babel-loader": "^8.0.6",
+    "babel-plugin-styled-components": "^1.10.6",
     "css-loader": "^3.2.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.1",

--- a/tests/CircleChevron.react.test.js
+++ b/tests/CircleChevron.react.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Enzyme, { shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import CircleChevron from '../client/components/CircleChevron';
 
 describe('CircleChevron Component', () => {

--- a/tests/ImageSelection.react.test.js
+++ b/tests/ImageSelection.react.test.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import ImageSelection from '../client/components/ImageSelection';
+import ThumbnailChevron from '../client/components/ThumbnailChevron';
+
+describe('Image Selection', () => {
+  test('It should not display chevrons when there are less than nine imags', () => {
+    let productImages = [
+      "http://picsum.photos/id/445/650/400#0",
+      "http://picsum.photos/id/3/650/400#1",
+      "http://picsum.photos/id/225/650/400#2",
+      "http://picsum.photos/id/21/650/400#3",
+      "http://picsum.photos/id/20/650/400#4",
+    ];
+    const wrapper = shallow(
+      <ImageSelection 
+        productImages={productImages}
+        selectedImageIndex={0}
+        selectImage={() => {}}
+      />
+    );
+    
+    expect(wrapper.find(ThumbnailChevron).length).toEqual(0);
+  });
+
+  test('It should display chevrons when there are more than nine images', () => {
+    let productImages = [
+      "http://picsum.photos/id/445/650/400#0",
+      "http://picsum.photos/id/3/650/400#1",
+      "http://picsum.photos/id/225/650/400#2",
+      "http://picsum.photos/id/21/650/400#3",
+      "http://picsum.photos/id/20/650/400#4",
+      "http://picsum.photos/id/201/650/400#5",
+      "http://picsum.photos/id/2/650/400#6",
+      "http://picsum.photos/id/180/650/400#7",
+      "http://picsum.photos/id/160/650/400#8",
+      "http://picsum.photos/id/119/650/400#9",
+      "http://picsum.photos/id/445/650/400#10",
+      "http://picsum.photos/id/3/650/400#11",
+      "http://picsum.photos/id/225/650/400#12",
+      "http://picsum.photos/id/21/650/400#13",
+      "http://picsum.photos/id/20/650/400#14",
+      "http://picsum.photos/id/201/650/400#15",
+      "http://picsum.photos/id/2/650/400#16",
+      "http://picsum.photos/id/180/650/400#17",
+      "http://picsum.photos/id/160/650/400#18",
+      "http://picsum.photos/id/119/650/400#19"
+    ];
+    const wrapper = shallow(
+      <ImageSelection 
+        productImages={productImages}
+        selectedImageIndex={0}
+        selectImage={() => {}}
+      />
+    );
+    
+    expect(wrapper.find(ThumbnailChevron).length).toEqual(2);
+  });
+
+  test('It should properly change the translate prop when a chevron is clicked', () => {
+    let productImages = [
+      "http://picsum.photos/id/445/650/400#0",
+      "http://picsum.photos/id/3/650/400#1",
+      "http://picsum.photos/id/225/650/400#2",
+      "http://picsum.photos/id/21/650/400#3",
+      "http://picsum.photos/id/20/650/400#4",
+      "http://picsum.photos/id/201/650/400#5",
+      "http://picsum.photos/id/2/650/400#6",
+      "http://picsum.photos/id/180/650/400#7",
+      "http://picsum.photos/id/160/650/400#8",
+      "http://picsum.photos/id/119/650/400#9",
+      "http://picsum.photos/id/445/650/400#10",
+      "http://picsum.photos/id/3/650/400#11",
+      "http://picsum.photos/id/225/650/400#12",
+      "http://picsum.photos/id/21/650/400#13",
+      "http://picsum.photos/id/20/650/400#14",
+      "http://picsum.photos/id/201/650/400#15",
+      "http://picsum.photos/id/2/650/400#16",
+      "http://picsum.photos/id/180/650/400#17",
+      "http://picsum.photos/id/160/650/400#18",
+      "http://picsum.photos/id/119/650/400#19"
+    ];
+    const wrapper = mount(
+      <ImageSelection 
+        productImages={productImages}
+        selectedImageIndex={0}
+        selectImage={() => {}}
+      />
+    );
+
+    wrapper.find(ThumbnailChevron).at(1).simulate('click');
+    // console.log(wrapper.find('ImageSelection__ImageContainer').props())
+    expect(wrapper.find('ImageSelection__ImageContainer').props().translate).toEqual(-603);
+    wrapper.find(ThumbnailChevron).at(0).simulate('click');
+    expect(wrapper.find('ImageSelection__ImageContainer').props().translate).toEqual(0);
+
+    // expect(wrapper.find(ThumbnailChevron).length).toEqual(2);
+  });
+
+
+})
+

--- a/tests/MainPicture.react.test.js
+++ b/tests/MainPicture.react.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Enzyme, { shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import MainPicture from '../client/components/MainPicture';
 import CircleChevron from '../client/components/CircleChevron';
 

--- a/tests/SlideShow.react.test.js
+++ b/tests/SlideShow.react.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Enzyme, { mount } from 'enzyme';
+import { mount } from 'enzyme';
 import SlideShow from '../client/components/SlideShow';
 import ImageSelection from '../client/components/ImageSelection';
 import MainPicture from '../client/components/MainPicture';


### PR DESCRIPTION
Chevrons only display when there are more than nine images. When clicked, they slide images into view left or right depending on which chevron is clicked. This is achieved by updating that translate property on the image-container element.

When the main image chevrons are clicked so that an image is selected is not currently in view, that image is slid into view in the image-container element.

Tests are included.